### PR TITLE
Make `FoundationPose` support texture-less rendering 

### DIFF
--- a/detection_6d_foundationpose/src/foundationpose_render.cu.hpp
+++ b/detection_6d_foundationpose/src/foundationpose_render.cu.hpp
@@ -48,7 +48,7 @@ void rasterize(
 
 void interpolate(
     cudaStream_t stream, float* attr_ptr, float* rast_ptr, int32_t* tri_ptr, float* out, int num_vertices,
-    int num_triangles, int attr_dim, int H, int W, int C);
+    int num_triangles, int attr_shape_dim, int attr_dim, int H, int W, int C);
     
 void texture(
     cudaStream_t stream, float* tex_ptr, float* uv_ptr, float* out, int tex_height, int tex_width, int tex_channel,
@@ -70,6 +70,17 @@ void transform_points(cudaStream_t stream, const float* transform_matrixs, int t
  */
 void generate_pose_clip(cudaStream_t stream, const float* transform_matrixs, const float* bbox2d_matrix, int transform_num, const float* points_vectors, 
     int points_num, float* transformed_points_vectors, int rgb_H, int rgb_W);
+
+/**
+ * @param transform_matrixs 应当是`Col-Major`的transform_num个4x4矩阵
+ * @param normals_vectors 应当是`normals_num`个3x1向量
+ * @param transformed_normal_vectors 这里直接输出归一化后的z方向分量，供 `transform_num x normals_num`个，即 [hyp-pose, H, W, 1] 
+ */
+void transform_normals(cudaStream_t stream, const float* transform_matrixs, int transform_num, const float* normals_vectors, 
+    int normals_num, float* transformed_normal_vectors);
+
+void refine_color(cudaStream_t stream, const float* color, const float* diffuse_intensity_map, const float* rast, float* output,
+    int poses_num, float w_ambient, float w_diffuse, int rgb_H, int rgb_W);
 
 }   // namespace foundationpose_render
 

--- a/detection_6d_foundationpose/src/foundationpose_render.hpp
+++ b/detection_6d_foundationpose/src/foundationpose_render.hpp
@@ -64,6 +64,10 @@ private:
                   const std::vector<Eigen::MatrixXf>& tfs,
                   float* output_buffer) ;
 
+  bool TransformVertexNormalsOnCUDA(cudaStream_t stream,
+                  const std::vector<Eigen::MatrixXf>& tfs,
+                  float* output_buffer);
+
   bool GeneratePoseClipOnCUDA(cudaStream_t stream,
                       float* output_buffer,
                       const std::vector<Eigen::MatrixXf>& poses, 
@@ -121,6 +125,7 @@ private:
   using DeviceBufferUniquePtrType = std::unique_ptr<T, std::function<void(T*)>>;
 
   DeviceBufferUniquePtrType<float> vertices_device_ {nullptr};
+  DeviceBufferUniquePtrType<float> vertex_normals_device_ {nullptr};
   DeviceBufferUniquePtrType<float> texcoords_device_ {nullptr};
   DeviceBufferUniquePtrType<int32_t> mesh_faces_device_ {nullptr};
   DeviceBufferUniquePtrType<uint8_t> texture_map_device_ {nullptr};
@@ -128,6 +133,8 @@ private:
   DeviceBufferUniquePtrType<float> pose_clip_device_ {nullptr};
   DeviceBufferUniquePtrType<float> rast_out_device_ {nullptr};
   DeviceBufferUniquePtrType<float> pts_cam_device_ {nullptr};
+  DeviceBufferUniquePtrType<float> diffuse_intensity_device_ {nullptr};
+  DeviceBufferUniquePtrType<float> diffuse_intensity_map_device_ {nullptr};
   DeviceBufferUniquePtrType<float> texcoords_out_device_ {nullptr};
   DeviceBufferUniquePtrType<float> color_device_ {nullptr};
   DeviceBufferUniquePtrType<float> xyz_map_device_ {nullptr};

--- a/detection_6d_foundationpose/src/foundationpose_sampling.cpp
+++ b/detection_6d_foundationpose/src/foundationpose_sampling.cpp
@@ -200,7 +200,7 @@ std::vector<Eigen::Matrix4f> MakeRotationGrid(unsigned int n_views = 40, int inp
       auto R_inplane = Eigen::Affine3f::Identity();
       R_inplane.rotate(Eigen::AngleAxisf(0, Eigen::Vector3f::UnitX()))
           .rotate(Eigen::AngleAxisf(0, Eigen::Vector3f::UnitY()))
-          .rotate(Eigen::AngleAxisf(inplane_rot, Eigen::Vector3f::UnitZ()));
+          .rotate(Eigen::AngleAxisf(inplane_rot * M_PI / 180.0f, Eigen::Vector3f::UnitZ()));
 
       cam_in_ob = cam_in_ob * R_inplane.matrix();
       Eigen::Matrix4f ob_in_cam = cam_in_ob.inverse();

--- a/detection_6d_foundationpose/src/foundationpose_utils.cpp
+++ b/detection_6d_foundationpose/src/foundationpose_utils.cpp
@@ -148,6 +148,7 @@ TexturedMeshLoader::TexturedMeshLoader(const std::string& mesh_file_path,
   // Walk through each of the mesh's vertices
   for (unsigned int v = 0; v < mesh->mNumVertices; v++) {
     vertices_.push_back(mesh->mVertices[v]);
+    vertex_normals_.push_back(mesh->mNormals[v]);
   }
   for (unsigned int i = 0 ; i < AI_MAX_NUMBER_OF_TEXTURECOORDS ; ++ i) {
     if (mesh->mTextureCoords[i] != nullptr) {
@@ -167,11 +168,11 @@ TexturedMeshLoader::TexturedMeshLoader(const std::string& mesh_file_path,
   LOG(INFO) << "Loading textured map file: " << textured_file_path;
   texture_map_ = cv::imread(textured_file_path);
   if (texture_map_.empty()) {
-    throw std::runtime_error("[TexturedMeshLoader] Failed to read textured image: "
-                            + textured_file_path);
+    // throw std::runtime_error("[TexturedMeshLoader] Failed to read textured image: "
+    //                         + textured_file_path);
+    texture_map_ = cv::Mat(2, 2, CV_8UC3, {100, 100, 100});
   }
   cv::cvtColor(texture_map_, texture_map_, cv::COLOR_BGR2RGB);
-
 
   LOG(INFO) << "Successfully Loaded textured mesh file!!!";
   LOG(INFO) << "Mesh has vertices_num: " << vertices_.size()
@@ -215,6 +216,17 @@ const std::vector<aiVector3D> &
 TexturedMeshLoader::GetMeshVertices() const noexcept
 {
   return vertices_;
+}
+
+/**
+ * @brief 获取mesh模型顶点的法向量
+ * 
+ * @return const std::vector<aiVector3D> &
+ */
+const std::vector<aiVector3D> & 
+TexturedMeshLoader::GetMeshVertexNormals() const noexcept
+{
+  return vertex_normals_;
 }
 
 /**

--- a/detection_6d_foundationpose/src/foundationpose_utils.hpp
+++ b/detection_6d_foundationpose/src/foundationpose_utils.hpp
@@ -69,6 +69,13 @@ public:
   const std::vector<aiVector3D> & GetMeshVertices() const noexcept;
 
   /**
+   * @brief 获取mesh模型顶点的法向量
+   * 
+   * @return const std::vector<aiVector3D> &
+   */
+  const std::vector<aiVector3D> & GetMeshVertexNormals() const noexcept;
+
+  /**
    * @brief 获取mesh模型的外观坐标系
    * 
    * @return const std::vector<aiVector3D> &
@@ -114,6 +121,7 @@ private:
   float mesh_diamter_;
   Eigen::Vector3f mesh_center_;
   std::vector<aiVector3D> vertices_;
+  std::vector<aiVector3D> vertex_normals_;
   std::vector<std::vector<aiVector3D>> texcoords_;
   std::vector<aiFace> faces_;
   Eigen::Matrix4f obb_;


### PR DESCRIPTION
- Align rendering input with `FoundationPose` in Python.
- Make `FoundationPose` support texture-less rendering.